### PR TITLE
fix getServerState issue

### DIFF
--- a/components/HitCompo.tsx
+++ b/components/HitCompo.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { BaseHit } from "instantsearch.js";
 import { useHits, UseHitsProps } from "react-instantsearch-hooks-web";
 import { Link } from "next-translate-routes";
+import { LinkNext } from "./LinkNext";
 
 interface HitModel {
   hit: any;
@@ -12,7 +13,7 @@ export const HitCompo = (props: HitModel) => {
     return null;
   }
   return (
-    <Link href={`/carte/${props.hit.objectID}`} passHref>
+    <LinkNext url={`/carte/${props.hit.objectID}`}>
       <div className="card">
         <div className="card-image">
           <Image
@@ -30,6 +31,6 @@ export const HitCompo = (props: HitModel) => {
           </div>
         </div>
       </div>
-    </Link>
+    </LinkNext>
   );
 };

--- a/components/LinkHome.tsx
+++ b/components/LinkHome.tsx
@@ -1,9 +1,10 @@
 import { Link } from "next-translate-routes";
+import { LinkNext } from "./LinkNext";
 
 export const LinkHome = () => {
   return (
-    <Link href="/">
+    <LinkNext url="/">
       <div>Accueil</div>
-    </Link>
+    </LinkNext>
   );
 };

--- a/components/LinkNext.tsx
+++ b/components/LinkNext.tsx
@@ -1,4 +1,4 @@
-import { Link } from "next-translate-routes";
+import { Link, useRouter } from "next-translate-routes";
 import { UrlObject } from "url";
 
 interface LinkNextProps {
@@ -8,7 +8,9 @@ interface LinkNextProps {
 }
 
 export const LinkNext = (props: LinkNextProps) => {
-  return props.url ? (
+  const router = useRouter();
+
+  return router && props.url ? (
     <Link href={props.url} passHref>
       <a onClick={props.onClick}>{props.children}</a>
     </Link>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "8.27.0",
     "eslint-config-next": "13.0.3",
     "i18next-http-backend": "^1.4.4",
-    "instantsearch-router-next-experimental": "^0.0.5",
+    "instantsearch-router-next-experimental": "^0.2.0",
     "next": "12.3.1",
     "next-i18next": "^11.0.0",
     "next-translate-routes": "^1.8.0",

--- a/pages/carte/[id]/index.tsx
+++ b/pages/carte/[id]/index.tsx
@@ -11,6 +11,7 @@ import { renderToString } from "react-dom/server";
 import { ParsedUrlQuery } from "querystring";
 import { LinkHome } from "../../../components/LinkHome";
 import { Card } from "../../../components/Card";
+import singletonRouter from "next-translate-routes/router";
 
 interface CarteProps {
   serverState?: InstantSearchServerState;
@@ -38,6 +39,7 @@ const Carte = (props: CarteProps) => {
         routing={{
           router: createInstantSearchNextRouter({
             serverUrl: props.serverUrl,
+            singletonRouter,
           }),
         }}
       >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import { GetServerSideProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { getServerState } from "react-instantsearch-hooks-server";
 import { renderToString } from "react-dom/server";
+import singletonRouter from "next-translate-routes/router";
 
 const connectionAlgolia = {
   testSandBox: ["latency", "6be0576ff61c053d5f9a3225e2a90f76"],
@@ -37,6 +38,7 @@ const Home = (props: HomeProps) => {
         routing={{
           router: createInstantSearchNextRouter({
             serverUrl: props.serverUrl,
+            singletonRouter,
           }),
         }}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-instantsearch-router-next-experimental@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/instantsearch-router-next-experimental/-/instantsearch-router-next-experimental-0.0.5.tgz#a76cfb09a947291541f3bc1d772fb250d2fa0601"
-  integrity sha512-M8Et0jMTzGyeP2rKENyCIOwGzSLRYjob9umt1OR63A48bgZWHvGf13PdioUX+wcDoHfhVomH8m7DyrtCKlOUvQ==
+instantsearch-router-next-experimental@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/instantsearch-router-next-experimental/-/instantsearch-router-next-experimental-0.2.0.tgz#440a5c222a627417ec999f8513a1733f2cc12bb8"
+  integrity sha512-HQImvL6sM6hpV1gJiE1tnlVeM/F4YuE7qwOVG4qv2gyluhy/5ktnMwp6RhittUMKcx2LUC0qGo3cSHakgzIRKQ==
   dependencies:
     qs "^6.5.1 < 6.10"
 


### PR DESCRIPTION
Bonjour, j'ai répondu au support mais j'ai décidé de push ma solution ici aussi :) 

Le soucis n'était pas du tout lié au router d'InstantSearch, c'est parce que le composant `<Link>` de la librairie `next-translate-routes` que vous utilisez ne gère pas les cas dans lesquels le router Next n'est pas instancié, ce qui est le cas dans `getServerState`.

Je vous propose donc dans un premier temps d'ouvrir une issue sur leur repo sachant que les `<Link>` de `next/router` n'ont pas ce soucis, je pense que ça devrait être ISO de leur côté aussi.

Mais je ne reviens pas les mains vides, donc voici un petit workaround. Dans tout ce qui est rendered par `getServerState` je vous propose de wrapper les éventuels `<Link>` dans un composant qui vérifie que le router est instancié (via `useRouter`), le cas échéant on n'utilise pas `<Link>` pour que la librairie ne plante pas.

J'ai aussi ajouté le singleton du router de `next-translate-routes` comme option à `createInstantSearchNextRouter` au cas où, même si ça a l'air compatible avec celui de base.

Normalement avec ça tout devrait fonctionner.